### PR TITLE
Add German README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository now contains a basic autonomous code generation system built in Python. The system uses open-source models from Hugging Face to generate code for development tasks.
 
+---
+
+## Deutsch
+
+Dieses Repository enthält ein grundlegendes autonomes Code-Generierungssystem in Python. Das System nutzt Open-Source-Modelle von Hugging Face, um Code für Entwicklungsaufgaben zu erzeugen.
+
 ## Setup
 
 1. Install Python 3.10 or newer.
@@ -15,6 +21,19 @@ This repository now contains a basic autonomous code generation system built in 
    ```
    The generated code will be written to `generated_code.py`.
 
+### Deutsche Anleitung
+
+1. Python 3.10 oder neuer installieren.
+2. Abh\u00e4ngigkeiten installieren:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Die CLI mit einer Aufgabenbeschreibung ausf\u00fchren:
+   ```bash
+   python -m ki_system.cli --task "Write a Python function to validate email addresses"
+   ```
+   Der generierte Code wird in `generated_code.py` gespeichert.
+
 ## Modules
 
 - **input_module.py** – reads tasks from CLI or text files.
@@ -24,4 +43,37 @@ This repository now contains a basic autonomous code generation system built in 
 - **feedback_module.py** – provides feedback based on evaluation results.
 - **cli.py** – command line entry point.
 
+### Module auf Deutsch
+
+- **input_module.py** – liest Aufgaben von der Kommandozeile oder aus Textdateien.
+- **analysis_module.py** – bestimmt Zielsprache und Komplexität.
+- **code_generator.py** – lädt ein Hugging-Face-Modell (z. B. `bigcode/starcoderbase`) und erzeugt Code.
+- **evaluator.py** – führt einfache Syntaxprüfungen durch.
+- **feedback_module.py** – gibt Rückmeldungen basierend auf den Ergebnissen aus.
+- **cli.py** – Kommandozeileneinstiegspunkt.
+
 This structure offers a starting point for autonomous code generation workflows.
+
+Diese Struktur bietet einen Ausgangspunkt für autonome Code-Generierungsabläufe.
+
+---
+
+## Stock Analysis Tool
+
+The repository also contains an initial folder structure for a stock market analysis and forecasting project. The main components are located in `stock_analysis/`:
+
+- `data/` – placeholder for imported market data
+- `models/` – machine learning models
+- `src/` – Python source code
+- `tests/` – unit tests
+- `docs/` – project documentation
+
+### Aktienanalyse-Werkzeug (Deutsch)
+
+Dieses Repository enthält zudem eine erste Ordnerstruktur für ein Projekt zur Analyse und Prognose von Börsendaten. Die wichtigsten Komponenten befinden sich in `stock_analysis/`:
+
+- `data/` – Ablage für importierte Marktdaten
+- `models/` – Machine-Learning-Modelle
+- `src/` – Python-Quellcode
+- `tests/` – Unit-Tests
+- `docs/` – Projektdokumentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 transformers
 accelerate
 datasets
+pandas
+numpy
+matplotlib
+scikit-learn

--- a/stock_analysis/docs/README.md
+++ b/stock_analysis/docs/README.md
@@ -1,0 +1,19 @@
+# Stock Analysis Tool
+
+This folder contains documentation for the stock analysis project.
+
+- `data/` – raw and processed data files
+- `models/` – trained machine learning models
+- `src/` – application source code
+- `tests/` – unit tests
+
+---
+
+## Aktienanalyse-Werkzeug
+
+Dieses Verzeichnis enthält die Dokumentation für das Aktienanalyseprojekt.
+
+- `data/` – Roh- und verarbeitete Daten
+- `models/` – trainierte Machine-Learning-Modelle
+- `src/` – Quellcode der Anwendung
+- `tests/` – Unit-Tests

--- a/stock_analysis/src/__init__.py
+++ b/stock_analysis/src/__init__.py
@@ -1,0 +1,1 @@
+"""Stock analysis package."""

--- a/stock_analysis/src/analysis.py
+++ b/stock_analysis/src/analysis.py
@@ -1,0 +1,11 @@
+"""Analysis module.
+
+Contains functions for basic statistical analysis of stock data.
+"""
+
+import pandas as pd
+
+
+def moving_average(series: pd.Series, window: int) -> pd.Series:
+    """Return moving average of the series."""
+    return series.rolling(window=window).mean()

--- a/stock_analysis/src/cli.py
+++ b/stock_analysis/src/cli.py
@@ -1,0 +1,15 @@
+"""Command-line interface for the stock analysis tool."""
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stock analysis CLI")
+    parser.add_argument("symbol", help="Ticker symbol to analyze")
+    args = parser.parse_args()
+    # Placeholder: load data and run analysis
+    print(f"Analyzing {args.symbol} ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/stock_analysis/src/data_import.py
+++ b/stock_analysis/src/data_import.py
@@ -1,0 +1,9 @@
+"""Data import module.
+
+Handles fetching historical stock data from APIs or CSV files.
+"""
+
+
+def fetch_data(symbol: str):
+    """Placeholder function to fetch data for a given symbol."""
+    pass

--- a/stock_analysis/src/database.py
+++ b/stock_analysis/src/database.py
@@ -1,0 +1,12 @@
+"""Database module.
+
+Provides functions to interact with the SQLite database.
+"""
+
+import sqlite3
+
+
+def init_db(path: str):
+    """Initialize the database at the given path."""
+    conn = sqlite3.connect(path)
+    conn.close()

--- a/stock_analysis/src/ml_model.py
+++ b/stock_analysis/src/ml_model.py
@@ -1,0 +1,13 @@
+"""ML model module.
+
+Placeholder for machine learning model training and prediction.
+"""
+
+from sklearn.linear_model import LinearRegression
+
+
+def train_model(features, targets):
+    """Train a simple linear regression model."""
+    model = LinearRegression()
+    model.fit(features, targets)
+    return model


### PR DESCRIPTION
## Summary
- translate main README to German
- add German translation for stock_analysis docs README

## Testing
- `python -m py_compile stock_analysis/src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68619c6c4e60832b889ade3ee3398cdb